### PR TITLE
Fixed sitemap product link generation

### DIFF
--- a/controller/jobs/templates/product/export/sitemap-items-body-default.xml
+++ b/controller/jobs/templates/product/export/sitemap-items-body-default.xml
@@ -18,7 +18,7 @@ $freq = $enc->xml( $this->get( 'siteFreq', 'daily' ) );
 <?php foreach( $this->get( 'siteItems', array() ) as $id => $item ) : ?>
 <?php
 		$date = str_replace( ' ', 'T', $item->getTimeModified() ) . date( 'P' );
-		$params = array( 'a-name' => str_replace( ' ', '-', strip_tags( $item->getName() ) ), 'd-product-id' => $id );
+		$params = array( 'd_name' => $item->getName( 'url' ), 'd_prodid' => $id );
 		$url = $this->url( $detailTarget, $detailCntl, $detailAction, $params, array(), $detailConfig );
 ?>
 	<url><loc><?php echo $enc->xml( $url ); ?></loc><lastmod><?php echo $date; ?></lastmod><changefreq><?php echo $freq; ?></changefreq></url>


### PR DESCRIPTION
The sitemap job created incorrect product URLs using (seemingly) deprecated URL parameters. This change alters them to be in line with the parameters used in the shop, e.g. in client/html/templates/catalog/lists/items-body.list.php