### PR TITLE
FIX | fix wrong syntax in $baseRef array

### DIFF
--- a/controller/jobs/src/Controller/Jobs/Order/Export/Csv/Standard.php
+++ b/controller/jobs/src/Controller/Jobs/Order/Export/Csv/Standard.php
@@ -256,7 +256,7 @@ class Standard
 	protected function export( array $processors, $msg, $maxcnt )
 	{
 		$lcontext = $this->getLocaleContext( $msg );
-		$baseRef = ['order/base/address', 'order.base.coupon', 'order/base/product', 'order/base/service'];
+		$baseRef = ['order/base/address', 'order/base/coupon', 'order/base/product', 'order/base/service'];
 
 		$manager = \Aimeos\MShop\Factory::createManager( $lcontext, 'order' );
 		$baseManager = \Aimeos\MShop\Factory::createManager( $lcontext, 'order/base' );

--- a/controller/jobs/tests/Controller/Jobs/Order/Export/Csv/StandardTest.php
+++ b/controller/jobs/tests/Controller/Jobs/Order/Export/Csv/StandardTest.php
@@ -103,6 +103,8 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$address2 = fgetcsv( $fp );
 		$service1 = fgetcsv( $fp );
 		$service2 = fgetcsv( $fp );
+		$coupon1 = fgetcsv($fp);
+		$coupon2 = fgetcsv($fp);
 		$product1 = fgetcsv( $fp );
 		$product2 = fgetcsv( $fp );
 		$product3 = fgetcsv( $fp );
@@ -116,6 +118,8 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals( 'address', $address2[0] );
 		$this->assertEquals( 'service', $service1[0] );
 		$this->assertEquals( 'service', $service2[0] );
+		$this->assertEquals( 'coupon', $coupon1[0]);
+		$this->assertEquals( 'coupon', $coupon2[0]);
 		$this->assertEquals( 'product', $product1[0] );
 		$this->assertEquals( 'product', $product2[0] );
 		$this->assertEquals( 'product', $product3[0] );


### PR DESCRIPTION
Change the dots to slashes, so the $order->coupons array is filled and in the export with the default mapping, the coupon code is written to CSV file.