### PR TITLE
[BUGFIX] attribute type in listMap 

### DIFF
--- a/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Attribute/Standard.php
+++ b/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Attribute/Standard.php
@@ -123,7 +123,7 @@ class Standard
 		foreach( $listItems as $listItem )
 		{
 			if( ( $refItem = $listItem->getRefItem() ) !== null ) {
-				$listMap[$refItem->getCode()][$listItem->getType()] = $listItem;
+				$listMap[$refItem->getCode()][$refItem->getType()][$listItem->getType()] = $listItem;
 			}
 		}
 
@@ -143,9 +143,9 @@ class Standard
 			{
 				$code = trim( $code );
 
-				if( isset( $listMap[$code][$listtype] ) )
+				if( isset( $listMap[$code][$attrType][$listtype] ) )
 				{
-					$listItem = $listMap[$code][$listtype];
+					$listItem = $listMap[$code][$attrType][$listtype];
 					unset( $listItems[$listItem->getId()] );
 				}
 				else


### PR DESCRIPTION
That Bug was nasty. If a product has a code multiple times only the first list will be used.
So only the first attribute will get imported.