### PR TITLE
Fix media import with external urls

### DIFF
--- a/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
+++ b/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
@@ -224,17 +224,10 @@ class Standard
 				$refItem->setPreviews( $map )->setUrl( $url );
 			} elseif( isset( $list['media.preview'] ) ) {
 				$refItem->setPreview( $list['media.preview'] )->setUrl( $url );
-			} elseif( $fs->has( $url )
-				&& (
-					$refItem->getPreviews() === []
-					|| $refItem->getUrl() !== $url
-					|| !( $fs instanceof \Aimeos\MW\Filesystem\MetaIface )
-					|| date( 'Y-m-d H:i:s', $fs->time( $url ) ) > $refItem->getTimeModified()
-				)
+			} elseif( $fs->has( $url ) && ( $refItem->getPreviews() === [] || $refItem->getUrl() !== $url )
+				|| \Aimeos\MW\Str::starts( $url, ['https:', 'https:', 'data:'] )
 			) {
-				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ) );
-			} elseif( preg_match( '#^[a-zA-Z]{1,10}://#', $url ) === 1 ) {
-				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ), 'fs-media', true );
+				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ), 'fs-media' );
 			}
 
 			unset( $list['media.previews'], $list['media.preview'] );

--- a/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
+++ b/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
@@ -229,7 +229,7 @@ class Standard
 			} elseif( \Aimeos\MW\Str::starts( $url, ['http:', 'https:'] ) ) {
 				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ), 'fs-media', true );
 			} elseif( $fs->has( $url ) && ( $refItem->getPreviews() === [] || $refItem->getUrl() !== $url ) ) {
-				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ), 'fs-media' );
+				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ) );
 			}
 
 			unset( $list['media.previews'], $list['media.preview'] );

--- a/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
+++ b/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
@@ -224,13 +224,17 @@ class Standard
 				$refItem->setPreviews( $map )->setUrl( $url );
 			} elseif( isset( $list['media.preview'] ) ) {
 				$refItem->setPreview( $list['media.preview'] )->setUrl( $url );
-			} elseif( $refItem->getPreviews() === [] || $refItem->getUrl() !== $url
-				|| $fs->has( $url ) && (
-					!( $fs instanceof \Aimeos\MW\Filesystem\MetaIface )
+			} elseif( $fs->has( $url )
+				&& (
+					$refItem->getPreviews() === []
+					|| $refItem->getUrl() !== $url
+					|| !( $fs instanceof \Aimeos\MW\Filesystem\MetaIface )
 					|| date( 'Y-m-d H:i:s', $fs->time( $url ) ) > $refItem->getTimeModified()
 				)
 			) {
 				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ) );
+			} elseif( preg_match( '#^[a-zA-Z]{1,10}://#', $url ) === 1 ) {
+				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ), 'fs-media', true );
 			}
 
 			unset( $list['media.previews'], $list['media.preview'] );

--- a/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
+++ b/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
@@ -224,9 +224,11 @@ class Standard
 				$refItem->setPreviews( $map )->setUrl( $url );
 			} elseif( isset( $list['media.preview'] ) ) {
 				$refItem->setPreview( $list['media.preview'] )->setUrl( $url );
-			} elseif( $fs->has( $url ) && ( $refItem->getPreviews() === [] || $refItem->getUrl() !== $url )
-				|| \Aimeos\MW\Str::starts( $url, ['https:', 'https:', 'data:'] )
-			) {
+			} elseif( \Aimeos\MW\Str::starts( $url, 'data:' ) ) {
+				$refItem->setPreview( $url )->setUrl( $url );
+			} elseif( \Aimeos\MW\Str::starts( $url, ['http:', 'https:'] ) ) {
+				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ), 'fs-media', true );
+			} elseif( $fs->has( $url ) && ( $refItem->getPreviews() === [] || $refItem->getUrl() !== $url ) ) {
 				$refItem = \Aimeos\Controller\Common\Media\Factory::create( $context )->scale( $refItem->setUrl( $url ), 'fs-media' );
 			}
 


### PR DESCRIPTION
Importing media from CSV which contains a hyperlink results in an exception, because the controller does not check correctly if the file exists in the file system.
The force flag on the scale call is used in the media/scale controller to circumvent file system checks, which is required here, too.
The regex is the same as the one in \Aimeos\Controller\Common\Media\Standard::getFileContent used to determine external sources.