### PR TITLE
Bugfix: Better mime type assignment

### DIFF
--- a/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
+++ b/controller/common/src/Controller/Common/Product/Import/Csv/Processor/Media/Standard.php
@@ -162,7 +162,7 @@ class Standard
 					$refItem = $manager->create()->setType( $type );
 				}
 
-				$ext = pathinfo( $url, PATHINFO_EXTENSION );
+				$ext = strtolower( pathinfo( $url, PATHINFO_EXTENSION ) );
 				if( isset( $this->mimes[$ext] ) ) {
 					$refItem->setMimeType( $this->mimes[$ext] );
 				}


### PR DESCRIPTION
In CSV procuct import, media with file extensions like ".JPG" (upper case) could not match a mime type.