### PR TITLE
Product CSV import: Use existing product config as fallback

### DIFF
--- a/controller/jobs/src/Controller/Jobs/Product/Import/Csv/Standard.php
+++ b/controller/jobs/src/Controller/Jobs/Product/Import/Csv/Standard.php
@@ -562,8 +562,11 @@ class Standard
 				if( $map )
 				{
 					$type = $this->checkType( $this->getValue( $map, 'product.type', $product->getType() ) );
-					$map['product.config'] = $this->getValue( $map, 'product.config', $product->getConfig() );
-
+					
+					if( $config = $this->getValue( $map, 'product.config' ) ) {
+						$map['product.config'] = json_decode( $config ) ?: [];
+					}
+						
 					$product = $product->fromArray( $map, true );
 					$product = $manager->save( $product->setType( $type ) );
 

--- a/controller/jobs/src/Controller/Jobs/Product/Import/Csv/Standard.php
+++ b/controller/jobs/src/Controller/Jobs/Product/Import/Csv/Standard.php
@@ -556,26 +556,15 @@ class Standard
 			try
 			{
 				$code = trim( $code );
+				$product = $products[$code] ?? $manager->create();
+				$map = current( $this->getMappedChunk( $list, $mapping ) ); // there can only be one chunk for the base product data
 
-				if( isset( $products[$code] ) ) {
-					$product = $products[$code];
-				} else {
-					$product = $manager->create();
-				}
-
-				$map = $this->getMappedChunk( $list, $mapping );
-
-				if( isset( $map[0] ) ) // there can only be one chunk for the base product data
+				if( $map )
 				{
-					$type = $this->checkType( $this->getValue( $map[0], 'product.type', $product->getType() ) );
+					$type = $this->checkType( $this->getValue( $map, 'product.type', $product->getType() ) );
+					$map['product.config'] = $this->getValue( $map, 'product.config', $product->getConfig() );
 
-					if( isset( $map[0]['product.config'] ) ) {
-						$map[0]['product.config'] = json_decode( $map[0]['product.config'], true ) ?: [];
-					} else {
-						$map[0]['product.config'] = $product->getConfig();
-					}
-
-					$product = $product->fromArray( $map[0], true );
+					$product = $product->fromArray( $map, true );
 					$product = $manager->save( $product->setType( $type ) );
 
 					$list = $processor->process( $product, $list );

--- a/controller/jobs/src/Controller/Jobs/Product/Import/Csv/Standard.php
+++ b/controller/jobs/src/Controller/Jobs/Product/Import/Csv/Standard.php
@@ -568,7 +568,12 @@ class Standard
 				if( isset( $map[0] ) ) // there can only be one chunk for the base product data
 				{
 					$type = $this->checkType( $this->getValue( $map[0], 'product.type', $product->getType() ) );
-					$map[0]['product.config'] = json_decode( $map[0]['product.config'] ?? '[]', true ) ?: [];
+
+					if( isset( $map[0]['product.config'] ) ) {
+						$map[0]['product.config'] = json_decode( $map[0]['product.config'], true ) ?: [];
+					} else {
+						$map[0]['product.config'] = $product->getConfig();
+					}
 
 					$product = $product->fromArray( $map[0], true );
 					$product = $manager->save( $product->setType( $type ) );


### PR DESCRIPTION
See https://github.com/aimeos/ai-controller-jobs/commit/c51a666d7554e8b6424545b5b46c845b5a031323#commitcomment-63891047

- if a valid JSON string is provided, it is used
- if an invalid JSON string is provided, the fallback is `[]`
- if no value is provided, `$product->getConfig()` is used which either returns the existing product config or `[]` as fallback